### PR TITLE
Set rejectUnauthorized option to false, fixes #1

### DIFF
--- a/client_server_ssl_nodejs/client.js
+++ b/client_server_ssl_nodejs/client.js
@@ -8,7 +8,8 @@ var options = {
 	method: 'GET',
 	key: fs.readFileSync("keys/userB.key"),
 	cert: fs.readFileSync("certs/userB.crt"),
-	ca: fs.readFileSync("ca/ca.crt")
+	ca: fs.readFileSync("ca/ca.crt"),
+	rejectUnauthorized: false
 };
 
 var req = https.request(options, function(res) {

--- a/client_server_ssl_nodejs/server.js
+++ b/client_server_ssl_nodejs/server.js
@@ -7,7 +7,7 @@ var options = {
   cert: fs.readFileSync("certs/server.crt"),
   ca: fs.readFileSync("ca/ca.crt"),
   requestCert: true,
-  rejectUnauthorized: true 
+  rejectUnauthorized: false
 };
 
 https.createServer(options, function (req, res) {


### PR DESCRIPTION
I had the same problem, I think it's probably because by default nodejs does not accept any self-signed certs (`rejectUnauthorized` defaults to `true` for both client and server).
